### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,6 @@
 name: "Validate devcontainer-feature.json files"
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/zenless-lab/devcontainer-features/security/code-scanning/1](https://github.com/zenless-lab/devcontainer-features/security/code-scanning/1)

In general, to fix this issue you explicitly declare the permissions for the GITHUB_TOKEN at either the workflow root or per-job level, granting only what is required (often just `contents: read` for validation or CI jobs that do not write back to the repo or interact with issues/PRs).

For this workflow, the best fix without changing existing functionality is to add a root-level `permissions` block right under the workflow `name:` (or under `on:`), setting `contents: read`. The job only checks out the code and runs a validation action, so it does not need any write permissions. Root-level permissions will apply to all jobs in this workflow (currently only `validate`), and setting `contents: read` ensures the token can read repository contents but cannot write or perform administrative actions.

Concretely, in `.github/workflows/validate.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name:` and `on:` (or just after `on:` if you prefer that style). No additional imports or methods are needed since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
