### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: "CI - Test Features"
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/zenless-lab/devcontainer-features/security/code-scanning/4](https://github.com/zenless-lab/devcontainer-features/security/code-scanning/4)

In general, fix this by explicitly specifying a least-privilege `permissions` block either at the workflow root (applies to all jobs) or per job. Here, all jobs just need to check out the repository and run tests, so they only need read access to repository contents. The best minimal change is to add a top-level `permissions` block with `contents: read` just under the `name` (and before `on:`), which will secure all jobs including `test-global` (the one CodeQL flagged) without altering their functionality.

Concretely, in `.github/workflows/test.yaml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: "CI - Test Features"`) and line 2 (`on:`). No additional imports, methods, or definitions are needed, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
