### PR TITLE
Update chezmoi to version 1.0.2 and adjust dependencies

### DIFF
--- a/src/chezmoi/devcontainer-feature.json
+++ b/src/chezmoi/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "chezmoi",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "chezmoi",
     "description": "Installs chezmoi and optionally enables workspace development mode.",
     "documentationURL": "https://github.com/zenless-lab/devcontainer-features/tree/main/src/chezmoi",
@@ -12,8 +12,8 @@
         }
     },
     "dependsOn": {
-        "ghcr.io/zenless-lab/devcontainer-features/pkg:1": {
-            "pkg": "curl,ca-certificates,git"
+        "ghcr.io/zenless-lab/devcontainer-features/pkg:2": {
+            "pkg": "curl ca-certificates git"
         }
     },
     "installsAfter": [


### PR DESCRIPTION
This pull request makes minor updates to the `devcontainer-feature.json` for the `chezmoi` feature, primarily updating the version and adjusting package dependency formatting.

- Version update:
  * Bumped the `chezmoi` feature version from `1.0.1` to `1.0.2` to reflect the latest changes.

- Dependency management:
  * Updated the dependency to use `ghcr.io/zenless-lab/devcontainer-features/pkg:2` instead of version 1, and changed the `pkg` field format from comma-separated to space-separated package names.Updated version from 1.0.1 to 1.0.2 and adjusted package dependencies.